### PR TITLE
ScalarTypeHints: fixed missing open tag when typeHint is not found [#15]

### DIFF
--- a/src/Rules/ScalarTypeHints.php
+++ b/src/Rules/ScalarTypeHints.php
@@ -33,6 +33,9 @@ class ScalarTypeHints implements Rule
 		$file->fixer->beginChangeset();
 		foreach ($variables as $variable) {
 			$typeHint = $file->findPrevious(T_STRING, $variable, $openParenthesis);
+			if (!$typeHint) {
+				continue;
+			}
 			$file->fixer->replaceToken($typeHint, '');
 			$file->fixer->replaceToken($typeHint + 1, '');
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,13 +17,13 @@ function testRule(Babylon\Rules\Rule $rule, $fileSuffix = '')
 	$prophet = new Prophecy\Prophet();
 	$writer = $prophet->prophesize(Babylon\Writer::class);
 	$writer->writeFile(Argument::type('string'), Argument::type('string'))->will(function ($args) use ($ruleReflection, $fileSuffix) {
-		Tester\Assert::matchFile(__DIR__ . '/data/php5/' . $ruleReflection->getShortName() . $fileSuffix . '.php', $args[1]);
+		Tester\Assert::matchFile(__DIR__ . '/data/php5/' . $ruleReflection->getShortName() . ($fileSuffix ? '.' . $fileSuffix : '') . '.php', $args[1]);
 	});
 
 	$transpiler = new Babylon\Transpiler($writer->reveal(), [
 		$rule,
 	]);
 
-	$transpiler->transpile(new Babylon\File(__DIR__ . '/data/php7/' . $ruleReflection->getShortName() . $fileSuffix . '.php'));
+	$transpiler->transpile(new Babylon\File(__DIR__ . '/data/php7/' . $ruleReflection->getShortName() . ($fileSuffix ? '.' . $fileSuffix : '') . '.php'));
 	$prophet->checkPredictions();
 }

--- a/tests/cases/Rules/ScalarTypeHints.phpt
+++ b/tests/cases/Rules/ScalarTypeHints.phpt
@@ -3,3 +3,4 @@
 require __DIR__ . '/../../bootstrap.php';
 
 testRule(new Babylon\Rules\ScalarTypeHints());
+testRule(new Babylon\Rules\ScalarTypeHints(), 'noTypeHint');

--- a/tests/data/php5/ScalarTypeHints.noTypeHint.php
+++ b/tests/data/php5/ScalarTypeHints.noTypeHint.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Babylon\Tests;
+
+
+class Calculator
+{
+
+	public function add($a, $b)
+	{
+		return $a + $b;
+	}
+
+}

--- a/tests/data/php7/ScalarTypeHints.noTypeHint.php
+++ b/tests/data/php7/ScalarTypeHints.noTypeHint.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Babylon\Tests;
+
+
+class Calculator
+{
+
+	public function add($a, $b)
+	{
+		return $a + $b;
+	}
+
+}


### PR DESCRIPTION
ScalarTypeHints: fixed missing open tag when typeHint is not found [#15]

Fixes #15 
- [x] Add tests before merging
